### PR TITLE
Remove ivtools from Suggests and vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Imports:
     msm
 Suggests: 
     haven,
-    ivtools,
     knitr,
     lfe,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Make use of packages in Suggests list conditional on their availability
 
+* Remove **ivtools** from Suggests due to the current failure of its **ahaz** dependency package to build on 3 of the CRAN Linux sub-architectures
+
 # OneSampleMR 0.1.1
 
 * Fix an issue causing an R CMD check note in R 4.2.0

--- a/R/asmm.R
+++ b/R/asmm.R
@@ -1,7 +1,7 @@
 #' Additive structural mean model
 #'
 #' `asmm` is not a function. This helpfile is to note that the additive structural mean model (ASMM)
-#' is simply fit with a linear IV estimator, such as available in [`ivreg::ivreg()`] or [`AER::ivreg()`].
+#' is simply fit with a linear IV estimator, such as available in [`ivreg::ivreg()`].
 #'
 #' For a binary outcome the ASMM estimates a causal risk difference.
 #'

--- a/man/asmm.Rd
+++ b/man/asmm.Rd
@@ -5,7 +5,7 @@
 \title{Additive structural mean model}
 \description{
 \code{asmm} is not a function. This helpfile is to note that the additive structural mean model (ASMM)
-is simply fit with a linear IV estimator, such as available in \code{\link[ivreg:ivreg]{ivreg::ivreg()}} or \code{\link[AER:ivreg]{AER::ivreg()}}.
+is simply fit with a linear IV estimator, such as available in \code{\link[ivreg:ivreg]{ivreg::ivreg()}}.
 }
 \details{
 For a binary outcome the ASMM estimates a causal risk difference.

--- a/tests/testthat/test-msmm.R
+++ b/tests/testthat/test-msmm.R
@@ -587,7 +587,7 @@ test_that("Stata output check", {
 # Single instrument example ----
 test_that("Single instrument example", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # Data generation from the example in the ivtools ivglm() helpfile
   set.seed(9)
   n <- 1000
@@ -599,18 +599,18 @@ test_that("Single instrument example", {
   dat <- data.frame(Z, X, Y)
 
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  fitY.LZX <- glm(Y ~ X + Z + X*Z, family = "binomial", data = dat)
-  fitLogGest <- ivglm(estmethod = "g",
-                      X = "X",
-                      fitZ.L = fitZ.L,
-                      fitY.LZX = fitY.LZX,
-                      data = dat,
-                      link = "log",
-                      Y = "Y")
-  logcrr <- fitLogGest$est["X"]
-  logcrrse <- sqrt(fitLogGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # fitY.LZX <- glm(Y ~ X + Z + X*Z, family = "binomial", data = dat)
+  # fitLogGest <- ivglm(estmethod = "g",
+  #                     X = "X",
+  #                     fitZ.L = fitZ.L,
+  #                     fitY.LZX = fitY.LZX,
+  #                     data = dat,
+  #                     link = "log",
+  #                     Y = "Y")
+  logcrr <- 0.1314654 # fitLogGest$est["X"]
+  logcrrse <- 0.06035374 # sqrt(fitLogGest$vcov)
 
   fit01 <- msmm(Y ~ X | Z, data = dat)
   expect_equal(log(fit01$crrci[1]), logcrr, tolerance = 0.05, ignore_attr = "names")

--- a/tests/testthat/test-msmm.R
+++ b/tests/testthat/test-msmm.R
@@ -639,7 +639,6 @@ test_that("Single instrument example", {
 # check subset argument ----
 test_that("Check subset argument", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
   # Data generation from the example in the ivtools ivglm() helpfile
   set.seed(9)
   n <- 1000

--- a/tests/testthat/test-tsps.R
+++ b/tests/testthat/test-tsps.R
@@ -90,7 +90,7 @@ test_that("Single instrument example - logmult link", {
   # ivtools for comparison fit
   # library(ivtools)
   # fitZ.L <- glm(Z ~ 1, data = dat)
-  # dat$Y[dat$Y == 0] <- 0.001
+  dat$Y[dat$Y == 0] <- 0.001
   # fitY.LZX <- glm(Y ~ X + Z, family = Gamma(link = "log"), data = dat)
   # fitLogGest <- ivglm(estmethod = "g",
   #                     X = "X",
@@ -121,6 +121,7 @@ test_that("Single instrument example - logmult link", {
   stage2 <- glm(Y ~ xhat, family = Gamma(link = "log"))
   betamanual <- c(betamanual, coef(stage2))
   expect_equal(fit12$estci[,1], betamanual, ignore_attr = "names", tolerance = 1e-3)
+  dat$Y[dat$Y == 0.001] <- 0
 })
 
 test_that("Single instrument example - logit link", {
@@ -223,6 +224,7 @@ test_that("Multiple instrument example with covariates - logadd link", {
 test_that("Multiple instrument example with covariates - logmult link", {
   skip_on_cran()
 
+  dat$Y[dat$Y == 0] <- 0.001
   fit32 <- tsps(Y ~ X + C1 + C2 | G1 + G2 + G3 + C1 + C2, data = dat, link = "logmult")
   expect_output(print(fit32))
   smry32 <- summary(fit32)
@@ -236,6 +238,7 @@ test_that("Multiple instrument example with covariates - logmult link", {
   stage2 <- glm(Y ~ xhat + C1 + C2, family = Gamma(link = "log"), control = list(maxit = 1E2))
   betamanual <- c(betamanual, coef(stage2))
   expect_equal(fit32$estci[,1], betamanual, tolerance = 0.01, ignore_attr = TRUE)
+  dat$Y[dat$Y == 0.001] <- 0
 })
 
 test_that("Multiple instrument example with covariates - logit link", {

--- a/tests/testthat/test-tsps.R
+++ b/tests/testthat/test-tsps.R
@@ -12,23 +12,23 @@ dat <- data.frame(Z, X, Y)
 
 test_that("Single instrument example - identity link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "identity"), data = dat)
-  fitIdentGest <- ivglm(estmethod = "g",
-                      X = "X",
-                      fitZ.L = fitZ.L,
-                      fitY.LZX = fitY.LZX,
-                      data = dat,
-                      link = "identity",
-                      Y = "Y")
-  crd <- fitIdentGest$est["X"]
-  crdse <- sqrt(fitIdentGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "identity"), data = dat)
+  # fitIdentGest <- ivglm(estmethod = "g",
+  #                     X = "X",
+  #                     fitZ.L = fitZ.L,
+  #                     fitY.LZX = fitY.LZX,
+  #                     data = dat,
+  #                     link = "identity",
+  #                     Y = "Y")
+  crd <- 0.1064741 # fitIdentGest$est["X"]
+  crdse <- 0.04748229 # sqrt(fitIdentGest$vcov)
 
   fit01 <- tsps(Y ~ X | Z, data = dat, link = "identity")
-  expect_equal(fit01$estci[4,1], crd, ignore_attr = "names")
+  expect_equal(fit01$estci[4,1], crd, ignore_attr = "names", tolerance = 1e-5)
 
   expect_s3_class(fit01, "tsps")
 
@@ -49,20 +49,20 @@ test_that("Single instrument example - identity link", {
 
 test_that("Single instrument example - logadd link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  fitY.LZX <- glm(Y ~ X + Z, family = poisson, data = dat) # binomial(link = "log")
-  fitLogGest <- ivglm(estmethod = "g",
-                      X = "X",
-                      fitZ.L = fitZ.L,
-                      fitY.LZX = fitY.LZX,
-                      data = dat,
-                      link = "log",
-                      Y = "Y")
-  logcrr <- fitLogGest$est["X"]
-  logcrrse <- sqrt(fitLogGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # fitY.LZX <- glm(Y ~ X + Z, family = poisson, data = dat) # binomial(link = "log")
+  # fitLogGest <- ivglm(estmethod = "g",
+  #                     X = "X",
+  #                     fitZ.L = fitZ.L,
+  #                     fitY.LZX = fitY.LZX,
+  #                     data = dat,
+  #                     link = "log",
+  #                     Y = "Y")
+  logcrr <- 0.1314654 # fitLogGest$est["X"]
+  logcrrse <- 0.06035374 # sqrt(fitLogGest$vcov)
 
   fit11 <- tsps(Y ~ X | Z, data = dat, link = "logadd")
   expect_equal(fit11$estci[4,1], logcrr, tolerance = 0.05, ignore_attr = "names")
@@ -86,21 +86,21 @@ test_that("Single instrument example - logadd link", {
 
 test_that("Single instrument example - logmult link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  dat$Y[dat$Y == 0] <- 0.001
-  fitY.LZX <- glm(Y ~ X + Z, family = Gamma(link = "log"), data = dat)
-  fitLogGest <- ivglm(estmethod = "g",
-                      X = "X",
-                      fitZ.L = fitZ.L,
-                      fitY.LZX = fitY.LZX,
-                      data = dat,
-                      link = "log",
-                      Y = "Y")
-  logcrr <- fitLogGest$est["X"]
-  logcrrse <- sqrt(fitLogGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # dat$Y[dat$Y == 0] <- 0.001
+  # fitY.LZX <- glm(Y ~ X + Z, family = Gamma(link = "log"), data = dat)
+  # fitLogGest <- ivglm(estmethod = "g",
+  #                     X = "X",
+  #                     fitZ.L = fitZ.L,
+  #                     fitY.LZX = fitY.LZX,
+  #                     data = dat,
+  #                     link = "log",
+  #                     Y = "Y")
+  logcrr <- 0.1313029 # fitLogGest$est["X"]
+  logcrrse <- 0.06027666 # sqrt(fitLogGest$vcov)
 
   fit12 <- tsps(Y ~ X | Z, data = dat, link = "logmult")
   expect_equal(fit12$estci[4,1], logcrr, tolerance = 0.05, ignore_attr = "names")
@@ -120,25 +120,25 @@ test_that("Single instrument example - logmult link", {
   Y[Y == 0] <- 0.001
   stage2 <- glm(Y ~ xhat, family = Gamma(link = "log"))
   betamanual <- c(betamanual, coef(stage2))
-  expect_equal(fit12$estci[,1], betamanual, ignore_attr = "names")
+  expect_equal(fit12$estci[,1], betamanual, ignore_attr = "names", tolerance = 1e-3)
 })
 
 test_that("Single instrument example - logit link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "logit"), data = dat)
-  fitLogitGest <- ivglm(estmethod = "g",
-                      X = "X",
-                      fitZ.L = fitZ.L,
-                      fitY.LZX = fitY.LZX,
-                      data = dat,
-                      link = "logit",
-                      Y = "Y")
-  logcor <- fitLogitGest$est["X"]
-  logcorse <- sqrt(fitLogitGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "logit"), data = dat)
+  # fitLogitGest <- ivglm(estmethod = "g",
+  #                     X = "X",
+  #                     fitZ.L = fitZ.L,
+  #                     fitY.LZX = fitY.LZX,
+  #                     data = dat,
+  #                     link = "logit",
+  #                     Y = "Y")
+  logcor <- 0.6664956 # fitLogitGest$est["X"]
+  logcorse <- 0.2895276 # sqrt(fitLogitGest$vcov)
 
   fit21 <- tsps(Y ~ X | Z, data = dat, link = "logit")
   expect_equal(fit21$estci[4,1], logcor, tolerance = 0.1, ignore_attr = "names")

--- a/tests/testthat/test-tsri.R
+++ b/tests/testthat/test-tsri.R
@@ -156,6 +156,7 @@ test_that("Single instrument example - logmult link", {
   stage2 <- glm(Y ~ X + res, family = Gamma(link = "log"))
   betamanual <- c(betamanual, coef(stage2))
   expect_equal(fit12$estci[,1], betamanual, tolerance = 0.01, ignore_attr = "names")
+  dat$Y[dat$Y == 0.001] <- 0
 })
 
 test_that("Single instrument example - logit link", {

--- a/tests/testthat/test-tsri.R
+++ b/tests/testthat/test-tsri.R
@@ -12,24 +12,24 @@ dat <- data.frame(Z, X, Y)
 
 test_that("Single instrument example - identity link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "identity"), data = dat)
-  fitIdentGest <- ivglm(estmethod = "g",
-                        X = "X",
-                        fitZ.L = fitZ.L,
-                        fitY.LZX = fitY.LZX,
-                        data = dat,
-                        link = "identity",
-                        Y = "Y",
-                        ctrl = TRUE)
-  crd <- fitIdentGest$est["X"]
-  crdse <- sqrt(fitIdentGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "identity"), data = dat)
+  # fitIdentGest <- ivglm(estmethod = "g",
+  #                       X = "X",
+  #                       fitZ.L = fitZ.L,
+  #                       fitY.LZX = fitY.LZX,
+  #                       data = dat,
+  #                       link = "identity",
+  #                       Y = "Y",
+  #                       ctrl = TRUE)
+  crd <- 0.1064741 # fitIdentGest$est["X"]
+  crdse <- 0.04748229 # sqrt(fitIdentGest$vcov)
 
   fit01 <- tsri(Y ~ X | Z, data = dat, link = "identity")
-  expect_equal(fit01$estci[4,1], crd, ignore_attr = "names")
+  expect_equal(fit01$estci[4,1], crd, ignore_attr = "names", tolerance = 1e-5)
 
   expect_s3_class(fit01, "tsri")
 
@@ -82,21 +82,21 @@ test_that("gmm identity link check", {
 
 test_that("Single instrument example - logadd link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  fitY.LZX <- glm(Y ~ X + Z, family = poisson, data = dat) # binomial(link = "log")
-  fitLogGest <- ivglm(estmethod = "g",
-                      X = "X",
-                      fitZ.L = fitZ.L,
-                      fitY.LZX = fitY.LZX,
-                      data = dat,
-                      link = "log",
-                      Y = "Y",
-                      ctrl = TRUE)
-  logcrr <- fitLogGest$est["X"]
-  logcrrse <- sqrt(fitLogGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # fitY.LZX <- glm(Y ~ X + Z, family = poisson, data = dat) # binomial(link = "log")
+  # fitLogGest <- ivglm(estmethod = "g",
+  #                     X = "X",
+  #                     fitZ.L = fitZ.L,
+  #                     fitY.LZX = fitY.LZX,
+  #                     data = dat,
+  #                     link = "log",
+  #                     Y = "Y",
+  #                     ctrl = TRUE)
+  logcrr <- 0.1314654 # fitLogGest$est["X"]
+  logcrrse <- 0.06035374 # sqrt(fitLogGest$vcov)
 
   fit11 <- tsri(Y ~ X | Z, data = dat, link = "logadd")
   expect_equal(fit11$estci[4,1], logcrr, tolerance = 0.05, ignore_attr = "names")
@@ -120,22 +120,22 @@ test_that("Single instrument example - logadd link", {
 
 test_that("Single instrument example - logmult link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
   dat$Y[dat$Y == 0] <- 0.001
-  fitY.LZX <- glm(Y ~ X + Z, family = Gamma(link = "log"), data = dat)
-  fitLogGest <- ivglm(estmethod = "g",
-                      X = "X",
-                      fitZ.L = fitZ.L,
-                      fitY.LZX = fitY.LZX,
-                      data = dat,
-                      link = "log",
-                      Y = "Y",
-                      ctrl = TRUE)
-  logcrr <- fitLogGest$est["X"]
-  logcrrse <- sqrt(fitLogGest$vcov)
+  # fitY.LZX <- glm(Y ~ X + Z, family = Gamma(link = "log"), data = dat)
+  # fitLogGest <- ivglm(estmethod = "g",
+  #                     X = "X",
+  #                     fitZ.L = fitZ.L,
+  #                     fitY.LZX = fitY.LZX,
+  #                     data = dat,
+  #                     link = "log",
+  #                     Y = "Y",
+  #                     ctrl = TRUE)
+  logcrr <- 0.1313029 # fitLogGest$est["X"]
+  logcrrse <- 0.06027666 # sqrt(fitLogGest$vcov)
 
   fit12 <- tsri(Y ~ X | Z, data = dat, link = "logmult")
   expect_equal(fit12$estci[4,1], logcrr, tolerance = 0.05, ignore_attr = "names")
@@ -160,21 +160,21 @@ test_that("Single instrument example - logmult link", {
 
 test_that("Single instrument example - logit link", {
   skip_on_cran()
-  skip_if_not_installed("ivtools")
+  # skip_if_not_installed("ivtools")
   # ivtools for comparison fit
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, data = dat)
-  fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "logit"), data = dat)
-  fitLogitGest <- ivglm(estmethod = "g",
-                        X = "X",
-                        fitZ.L = fitZ.L,
-                        fitY.LZX = fitY.LZX,
-                        data = dat,
-                        link = "logit",
-                        Y = "Y",
-                        ctrl = TRUE)
-  logcor <- fitLogitGest$est["X"]
-  logcorse <- sqrt(fitLogitGest$vcov)
+  # library(ivtools)
+  # fitZ.L <- glm(Z ~ 1, data = dat)
+  # fitY.LZX <- glm(Y ~ X + Z, family = binomial(link = "logit"), data = dat)
+  # fitLogitGest <- ivglm(estmethod = "g",
+  #                       X = "X",
+  #                       fitZ.L = fitZ.L,
+  #                       fitY.LZX = fitY.LZX,
+  #                       data = dat,
+  #                       link = "logit",
+  #                       Y = "Y",
+  #                       ctrl = TRUE)
+  logcor <- 0.6666527 # fitLogitGest$est["X"]
+  logcorse <- 0.2896101 # sqrt(fitLogitGest$vcov)
 
   fit21 <- tsri(Y ~ X | Z, data = dat, link = "logit")
   expect_equal(fit21$estci[4,1], logcor, tolerance = 0.1, ignore_attr = "names")

--- a/vignettes/compare-smm-fits.Rmd
+++ b/vignettes/compare-smm-fits.Rmd
@@ -8,7 +8,6 @@ vignette: >
 ---
 
 ```{r, include=FALSE}
-evalcond <- requireNamespace("ivtools", quietly = TRUE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -33,33 +32,6 @@ X <- rbinom(n, 1, 0.7*Z + 0.2*(1 - Z))
 m0 <- plogis(1 + 0.8*X - 0.39*Z)
 Y <- rbinom(n, 1, plogis(psi0*X + log(m0/(1 - m0)))) 
 dat <- data.frame(Z, X, Y)
-```
-
-* Then fit MSMM using G-estimation.
-
-```{r, eval=evalcond}
-if (requireNamespace("ivtools", quietly = TRUE)) {
-  library(ivtools)
-  fitZ.L <- glm(Z ~ 1, family = "binomial", data = dat)
-  fitY.LZX <- glm(Y ~ X, family = "binomial", data = dat)
-  fit01 <- ivglm(estmethod = "g", X = "X", Y = "Y",
-                 fitZ.L = fitZ.L, fitY.LZX = fitY.LZX, 
-                 data = dat, link = "log")
-  print(summary(fit01))
-  print(confint(fit01))
-} else {
-  print("Package ivtools not available, so example not run")
-}
-```
-
-* Back transforming that estimate from the $\log(\text{CRR})$ scale to the $\text{CRR}$ scale.
-
-```{r, eval=evalcond}
-if (requireNamespace("ivtools", quietly = TRUE)) {
-  exp(cbind(fit01$est, confint(fit01)))
-} else {
-  print("Package ivtools not available, so example not run")
-}
 ```
 
 * Comparison fit using `msmm()`.


### PR DESCRIPTION
**OneSampleMR** is currently failing to build on 4 CRAN Linux sub-architectures. This is because **ivtools** is failing to build, which is because its own dependency **ahaz** is failing to build.

Hence this (hopefully temporarily) removes **ivtools**.