### PR TITLE
Replace ellipsis by rlang

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,12 +25,12 @@ BugReports: https://github.com/remlapmot/OneSampleMR/issues/
 Depends:
     R (>= 4.3)
 Imports:
-    ellipsis,
     Formula,
     gmm,
     ivreg,
     lmtest,
-    msm
+    msm,
+    rlang (>= 1.0.0)
 Suggests:
     haven,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# OneSampleMR
+
+* Replaced dots checking with rlang instead of the ellipsis package.
+
 # OneSampleMR 0.1.4
 
 * Add `CITATION` file

--- a/R/msmm.R
+++ b/R/msmm.R
@@ -150,7 +150,7 @@ msmm <- function(formula, instruments, data, subset, na.action,
   # weights, offset,
   # model = TRUE, y = TRUE, x = FALSE,
 
-  ellipsis::check_dots_used()
+  rlang::check_dots_used()
 
   # code from beginning for ivreg::ivreg()
   ## set up model.frame() call

--- a/R/tsps.R
+++ b/R/tsps.R
@@ -74,7 +74,7 @@ tsps <- function(formula, instruments, data, subset, na.action,
   # weights, offset,
   # model = TRUE, y = TRUE, x = FALSE,
 
-  ellipsis::check_dots_used()
+  rlang::check_dots_used()
 
   # code from beginning for ivreg::ivreg()
   ## set up model.frame() call

--- a/R/tsri.R
+++ b/R/tsri.R
@@ -87,7 +87,7 @@ tsri <- function(formula, instruments, data, subset, na.action,
   # weights, offset,
   # model = TRUE, y = TRUE, x = FALSE,
 
-  ellipsis::check_dots_used()
+  rlang::check_dots_used()
 
   # code from beginning for ivreg::ivreg()
   ## set up model.frame() call


### PR DESCRIPTION
Since ellipsis is deprecated (and imports rlang anyway) https://rlang.r-lib.org/news/index.html#argument-intake-1-0-0