### PR TITLE
Fix bug when either a covariate or an exposure was class factor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: OneSampleMR
 Title: One Sample Mendelian Randomization and Instrumental Variable
     Analyses
-Version: 0.1.5.9000
+Version: 0.1.6
 Authors@R: c(
     person("Tom", "Palmer", , "remlapmot@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4655-4511")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # OneSampleMR 0.1.5.9000
 
+* Fixed a bug in `fsw()` when an exogenous covariate was a factor (thanks @ZoeReed)
+
+* The `fsw()` function now returns an error if any of the exposures are factors
+
 # OneSampleMR 0.1.5
 
 * Replaced dots checking with rlang instead of the ellipsis package (thanks @olivroy).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# OneSampleMR 0.1.5.9000
+# OneSampleMR 0.1.6
 
 * Fixed a bug in `fsw()` when an exogenous covariate was a factor (thanks @ZoeReed)
 

--- a/R/fsw.R
+++ b/R/fsw.R
@@ -50,7 +50,12 @@ fsw.ivreg <- function(object) {
 
   ninstruments <- length(object$instruments)
   nexogenous <- length(object$exogenous) - 1
-  namesendog <- names(object$endogenous)
+  namesendog <- labels(object$terms$regressors)[1:nendog]
+  endogfcterrmsg <- paste("One or more of your exposure variables is a factor.",
+                          "Please convert to numeric with say as.numeric(),",
+                          "refit your ivreg() model, and rerun fsw().")
+  if ("factor" %in% lapply(object$model[namesendog], class)) stop(endogfcterrmsg)
+
   namesexog <- labels(object$terms$regressors)[-(1:nendog)]
   namesinstruments <- names(object$instruments)
   n <- object$n

--- a/R/fsw.R
+++ b/R/fsw.R
@@ -51,7 +51,7 @@ fsw.ivreg <- function(object) {
   ninstruments <- length(object$instruments)
   nexogenous <- length(object$exogenous) - 1
   namesendog <- names(object$endogenous)
-  namesexog <- names(object$exogenous[-1])
+  namesexog <- labels(object$terms$regressors)[-(1:nendog)]
   namesinstruments <- names(object$instruments)
   n <- object$n
   fsw <- fswdf <- fswresdf <- fswp <- numeric(nendog)


### PR DESCRIPTION
* Fixed a bug in `fsw()` when an exogenous covariate was a factor (thanks @ZoeReed)

* The `fsw()` function now returns an error if any of the exposures are factors

Fixes #11 