### PR TITLE
OneSampleMR 0.1.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: OneSampleMR
 Title: One Sample Mendelian Randomization and Instrumental Variable
     Analyses
-Version: 0.1.6.9000
+Version: 0.1.7
 Authors@R: c(
     person("Tom", "Palmer", , "remlapmot@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4655-4511")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# OneSampleMR (development version)
+# OneSampleMR 0.1.7
 
 * `fsw()` can now calculate Sanderson-Windmiejer conditional F statistics for models fitted by `AER::ivreg()`, `estimatr::iv_robust()`, and `fixest::feols()` (thanks @nvitt)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # OneSampleMR 0.1.7
 
-* `fsw()` can now calculate Sanderson-Windmiejer conditional F statistics for models fitted by `AER::ivreg()`, `estimatr::iv_robust()`, and `fixest::feols()` (thanks @nvitt)
+* `fsw()` can now calculate Sanderson-Windmeijer conditional F statistics for models fitted by `AER::ivreg()`, `estimatr::iv_robust()`, and `fixest::feols()` (thanks @nvitt)
 
 # OneSampleMR 0.1.6
 


### PR DESCRIPTION
* `fsw()` can now calculate Sanderson-Windmeijer conditional F statistics for models fitted by `AER::ivreg()`, `estimatr::iv_robust()`, and `fixest::feols()` (thanks @nvitt)
